### PR TITLE
Add the iPhone 4 (rev A) to the device list.  

### DIFF
--- a/FCUtilities/UIDevice+FCUtilities.m
+++ b/FCUtilities/UIDevice+FCUtilities.m
@@ -68,6 +68,7 @@ static FCDeviceCPUClass fcCPUClass;
         return (fcModelHumanIdentifier = @"iPad");
     } else {
         if ([mid isEqualToString:@"iPhone3,1"])  { fcCPUClass = FCDeviceCPUClassA4; return (fcModelHumanIdentifier = @"iPhone 4"); }
+        if ([mid isEqualToString:@"iPhone3,2"])  { fcCPUClass = FCDeviceCPUClassA4; return (fcModelHumanIdentifier = @"iPhone 4"); }
         if ([mid isEqualToString:@"iPhone3,3"])  { fcCPUClass = FCDeviceCPUClassA4; return (fcModelHumanIdentifier = @"iPhone 4 CDMA"); }
 
         if ([mid isEqualToString:@"iPhone4,1"])  { fcCPUClass = FCDeviceCPUClassA5; return (fcModelHumanIdentifier = @"iPhone 4S"); }


### PR DESCRIPTION
The identifier for this is iPhone3,2.  This is the 8gb variant that was released as the iPhone 4 was sent downmarket.

As the iPhone 4 is decidedly low performance compared to the other iOS 7 capable devices making sure all of them are correctly identified is important to adapt the experience as needed.

Ref: http://theiphonewiki.com/wiki/Models
