### PR TITLE
Export the activity type for FCOpenInChromeActivity.

### DIFF
--- a/FCUtilities/FCOpenInChromeActivity.h
+++ b/FCUtilities/FCOpenInChromeActivity.h
@@ -5,6 +5,8 @@
 
 #import <UIKit/UIKit.h>
 
+FOUNDATION_EXPORT NSString *const FCActivityTypeOpenInChrome;
+
 @interface FCOpenInChromeActivity : UIActivity
 
 - (instancetype)initWithSourceName:(NSString *)xCallbackSource successCallbackURL:(NSURL *)xCallbackURL;


### PR DESCRIPTION
The exported type allows one to check for the activity in `activityViewController:itemForActivityType:` and follows the pattern from `FCOpenInSafariActivity`.
