### PR TITLE
Updating device list

### DIFF
--- a/FCUtilities/UIDevice+FCUtilities.h
+++ b/FCUtilities/UIDevice+FCUtilities.h
@@ -17,6 +17,7 @@ typedef NS_ENUM(NSInteger, FCDeviceCPUClass) {
     FCDeviceCPUClassA6,
     FCDeviceCPUClassA7,
     FCDeviceCPUClassA8,
+    FCDeviceCPUClassA9,
     FCDeviceCPUClassUnknown
 };
 

--- a/FCUtilities/UIDevice+FCUtilities.m
+++ b/FCUtilities/UIDevice+FCUtilities.m
@@ -77,9 +77,18 @@ static FCDeviceRadioType fcRadioType;
         if ([mid isEqualToString:@"iPad4,7"]) { fcCPUClass = FCDeviceCPUClassA7; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPad Mini 3"); }
         if ([mid isEqualToString:@"iPad4,8"]) { fcCPUClass = FCDeviceCPUClassA7; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Mini 3"); }
         if ([mid isEqualToString:@"iPad4,9"]) { fcCPUClass = FCDeviceCPUClassA7; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Mini 3"); } // China
+        
+        if ([mid isEqualToString:@"iPad5,1"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPad Mini 4"); }
+        if ([mid isEqualToString:@"iPad5,2"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Mini 4"); }
 
         if ([mid isEqualToString:@"iPad5,3"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPad Air 2"); }
         if ([mid isEqualToString:@"iPad5,4"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Air 2"); }
+        
+        if ([mid isEqualToString:@"iPad6,7"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPad Pro 12.9-inch"); }
+        if ([mid isEqualToString:@"iPad6,8"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Pro 12.9-inch"); }
+        
+        if ([mid isEqualToString:@"iPad6,3"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPad Pro 9.7-inch"); }
+        if ([mid isEqualToString:@"iPad6,4"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPad Pro 9.7-inch"); }
         
         fcCPUClass = FCDeviceCPUClassUnknown;
         fcRadioType = FCDeviceRadioTypeUnknown;
@@ -105,6 +114,11 @@ static FCDeviceRadioType fcRadioType;
         if ([mid isEqualToString:@"iPhone7,1*"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6 Plus"); } // China
         if ([mid isEqualToString:@"iPhone7,2"])  { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6"); }
         if ([mid isEqualToString:@"iPhone7,2*"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6"); } // China
+        
+        if ([mid isEqualToString:@"iPhone8,1"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6s"); }
+        if ([mid isEqualToString:@"iPhone8,2"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6s Plus"); }
+        
+        if ([mid isEqualToString:@"iPhone8,4"]) { fcCPUClass = FCDeviceCPUClassA9; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone SE"); }
 
         if ([mid isEqualToString:@"iPod5,1"])    { fcCPUClass = FCDeviceCPUClassA5; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPod 5G"); }
         if ([mid isEqualToString:@"iPod7,1"])    { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeWiFiOnly; return (fcModelHumanIdentifier = @"iPod 6G"); }

--- a/FCUtilities/UIDevice+FCUtilities.m
+++ b/FCUtilities/UIDevice+FCUtilities.m
@@ -102,7 +102,7 @@ static FCDeviceRadioType fcRadioType;
         if ([mid isEqualToString:@"iPhone6,2"])  { fcCPUClass = FCDeviceCPUClassA7; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 5s"); }
 
         if ([mid isEqualToString:@"iPhone7,1"])  { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6 Plus"); }
-        if ([mid isEqualToString:@"iPhone7,2*"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6 Plus"); } // China
+        if ([mid isEqualToString:@"iPhone7,1*"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6 Plus"); } // China
         if ([mid isEqualToString:@"iPhone7,2"])  { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6"); }
         if ([mid isEqualToString:@"iPhone7,2*"]) { fcCPUClass = FCDeviceCPUClassA8; fcRadioType = FCDeviceRadioTypeCellular; return (fcModelHumanIdentifier = @"iPhone 6"); } // China
 


### PR DESCRIPTION
This adds checks for the iPhone 6s series, iPhone SE, iPad mini 4, and both iPad Pro sizes. It also corrects the model identifier for the iPhone 6 Plus for China, which was originally marked as iPhone7,2, but all online documentation points to it being iPhone7,1 like the other iPhone 6 Plus models. iPhone7,2 is only used for the 4.7 inch models. 