### PR TITLE
Twitter auth: Catch "Return to app" button

### DIFF
--- a/FCUtilities/FCTwitterAuthorization.m
+++ b/FCUtilities/FCTwitterAuthorization.m
@@ -143,7 +143,7 @@ static FCTwitterAuthorization *g_currentInstance = NULL;
         
         NSURL *authURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://api.twitter.com/oauth/authenticate?oauth_token=%@", oauth.token]];
         self.authenticationSession = [[SFAuthenticationSession alloc] initWithURL:authURL callbackURLScheme:self.callbackURLScheme completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable e) {
-            if (! callbackURL || e) {
+			if (! callbackURL || e || [callbackURL.absoluteString containsString:@"?denied="]) {
                 [self finishWithCredentials:nil];
                 return;
             }


### PR DESCRIPTION
don't crash when tapping "Cancel" (in Twitter web page) and then "Return to <App name>"