### PR TITLE
Fix: FCTwitterAuthorization's +isTwitterInstalled selector was previously not being used

### DIFF
--- a/FCUtilities/FCTwitterAuthorization.m
+++ b/FCUtilities/FCTwitterAuthorization.m
@@ -87,7 +87,7 @@ static FCTwitterAuthorization *g_currentInstance = NULL;
          self.consumerKey, self.consumerSecret, self.callbackURLScheme
     ]];
     
-    if ([UIApplication.sharedApplication canOpenURL:appAuthURL]) {
+    if ([FCTwitterAuthorization isTwitterAppInstalled]) {
         [UIApplication.sharedApplication openURL:appAuthURL options:@{} completionHandler:^(BOOL success) {
             if (! success) [self finishWithCredentials:nil];
         }];


### PR DESCRIPTION
Another possible fix is to entirely remove this static selector, but the author believes Marco and other FCUtilities users might be making use of it, so this was the preferred option.